### PR TITLE
Disabled the right-click context menu in the reactor grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,7 +205,7 @@
 								<span id="stats_cash" class="stat" title="Estimated autosell cash per tick">0</span>
 							</div>
 						</header>
-						<div id="reactor_wrapper">
+						<div id="reactor_wrapper" oncontextmenu="return false;">
 							<div id="tile_wrapper" class="subpanel">
 								<div id="reactor"></div>
 							</div>


### PR DESCRIPTION
Previously the menu appeared when trying to sell components.